### PR TITLE
add default host

### DIFF
--- a/crproxy.go
+++ b/crproxy.go
@@ -29,6 +29,7 @@ var (
 	prefix             = "/v2/"
 	catalog            = prefix + "_catalog"
 	speedLimitDuration = time.Second
+	defaultHost        = "docker.io"
 )
 
 type Logger interface {
@@ -651,6 +652,12 @@ func (p PathInfo) Path() (string, error) {
 
 func ParseOriginPathInfo(path string) (*PathInfo, bool) {
 	path = strings.TrimLeft(path, prefix)
+
+	// add default prefix if not exist
+	if !strings.HasPrefix(path, defaultHost) {
+		path = defaultHost + "/" + path
+	}
+
 	i := strings.IndexByte(path, '/')
 	if i <= 0 {
 		return nil, false


### PR DESCRIPTION
默认拼接docker.io，这样就可以docker pull gateway_domain/nginx:latest直接拉取镜像。
docker images看到的镜像名是`gateway_domain/nginx:latest`

现在的逻辑是 docker pull gateway_domain/docker.io/nginx:latest
docker images里镜像名字太长了：`gateway_domain/docker.io/nginx:latest`

更简洁点：
如果把gateway_domain写入daemon.json里
就可以直接docker pull nginx:latest拉取镜像。
docker images看到的镜像名是`nginx:latest`